### PR TITLE
Restored jsonpath expression formation to that of 2.1.1

### DIFF
--- a/src/morph_kgc/data_source/data_file.py
+++ b/src/morph_kgc/data_source/data_file.py
@@ -147,7 +147,7 @@ def _read_json(rml_rule, references):
     jsonpath_expression = rml_rule['iterator'] + '.('
     # add top level object of the references to reduce intermediate results (THIS IS NOT STRICTLY NECESSARY)
     for reference in references:
-        jsonpath_expression += reference + ','
+        jsonpath_expression += reference.split('.')[0] + ','
     jsonpath_expression = jsonpath_expression[:-1] + ')'
 
     jsonpath_result = JSONPath(jsonpath_expression).parse(json_data)


### PR DESCRIPTION
Current jsonpath expressions fail like exposed in https://github.com/morph-kgc/morph-kgc/issues/132
I have just restored read_json line related to formation of jsonpath_expression as it was in morph v. 2.1.1