### PR TITLE
Develop

### DIFF
--- a/src/morph_kgc/mapping/mapping_parser.py
+++ b/src/morph_kgc/mapping/mapping_parser.py
@@ -739,6 +739,16 @@ class MappingParser:
                             'Check the mapping files, one triple map cannot be repeated in different data sources.')
 
     def _normalize_rml_star(self):
+        num_rules_before_expansion = len(self.rml_df)
+        while True:
+            self._expand_rml_star()
+            if num_rules_before_expansion == len(self.rml_df):
+                break
+            else:
+                num_rules_before_expansion = len(self.rml_df)
+                self._expand_rml_star()
+
+    def _expand_rml_star(self):
         # create a unique id for each (normalized) mapping rule
         self.rml_df.insert(0, 'id', self.rml_df.reset_index(drop=True).index.astype(str))
         self.rml_df['id'] = '#TM' + self.rml_df['id']

--- a/test/issues/issue_124/output.nq
+++ b/test/issues/issue_124/output.nq
@@ -1,8 +1,10 @@
+<http://example/a> <http://example/q2> << <http://example/s> <http://example/p2> <http://example/o> >> .
+<http://example/s> <http://example/p1> <http://example/o> .
+<< <http://example/a> <http://example/q1> << <http://example/s> <http://example/p2> <http://example/o> >> >> <http://example/r> <http://example/z> .
+<< <http://example/a> <http://example/q2> << <http://example/s> <http://example/p2> <http://example/o> >> >> <http://example/r> <http://example/z> .
+<< <http://example/a> <http://example/q2> << <http://example/s> <http://example/p1> <http://example/o> >> >> <http://example/r> <http://example/z> .
 <http://example/a> <http://example/q2> << <http://example/s> <http://example/p1> <http://example/o> >> .
 << <http://example/a> <http://example/q1> << <http://example/s> <http://example/p1> <http://example/o> >> >> <http://example/r> <http://example/z> .
-<http://example/s> <http://example/p1> <http://example/o> .
-<http://example/a> <http://example/q1> << <http://example/s> <http://example/p1> <http://example/o> >> .
 <http://example/a> <http://example/q1> << <http://example/s> <http://example/p2> <http://example/o> >> .
-<< <http://example/a> <http://example/q2> << <http://example/s> <http://example/p1> <http://example/o> >> >> <http://example/r> <http://example/z> .
-<http://example/a> <http://example/q2> << <http://example/s> <http://example/p2> <http://example/o> >> .
 <http://example/s> <http://example/p2> <http://example/o> .
+<http://example/a> <http://example/q1> << <http://example/s> <http://example/p1> <http://example/o> >> .


### PR DESCRIPTION
Bug fix related to #124 .

In the case that multiple quoted triples maps had (all of them) multiple predicate-object maps, the system was not generating all the triples. Test case for #124 was wrong on the output triples generated, this is also fixed now.