### PR TITLE
Complete termtypes of refOM

### DIFF
--- a/src/morph_kgc/mapping/mapping_constants.py
+++ b/src/morph_kgc/mapping/mapping_constants.py
@@ -85,6 +85,7 @@ RML_PARSING_QUERY = """
             OPTIONAL {
                 ?_predicate_object_map rml:objectMap ?object_map .
                 ?object_map rml:parentTriplesMap ?object_map_value .
+                OPTIONAL { ?object_map rml:termType ?object_termtype . }
                 BIND ( rml:parentTriplesMap AS ?object_map_type ) .
             }
             OPTIONAL {

--- a/src/morph_kgc/mapping/mapping_parser.py
+++ b/src/morph_kgc/mapping/mapping_parser.py
@@ -257,6 +257,14 @@ def _complete_termtypes(mapping_graph):
     for om, _ in mapping_graph.query(query):
         mapping_graph.add((om, rdflib.term.URIRef(RML_TERM_TYPE), rdflib.term.URIRef(RML_LITERAL)))
 
+    # complete referencing object maps with the termtype coming from the subject of the parent
+    query = 'SELECT DISTINCT ?term_map ?termtype WHERE { ' \
+            f'?term_map <{RML_PARENT_TRIPLES_MAP}> ?parent_tm . ' \
+            f'?parent_tm <{RML_SUBJECT_MAP}> ?parent_subject_map . ' \
+            f'?parent_subject_map <{RML_TERM_TYPE}> ?termtype . }}'
+    for term_map, termtype in mapping_graph.query(query):
+        mapping_graph.add((term_map, rdflib.term.URIRef(RML_TERM_TYPE), rdflib.term.URIRef(termtype)))
+
     # now all missing termtypes are IRIs
     for term_map_property in [RML_SUBJECT_MAP, RML_PREDICATE_MAP, RML_OBJECT_MAP, RML_GRAPH_MAP]:
         query = 'SELECT DISTINCT ?term_map ?x WHERE { ' \

--- a/src/morph_kgc/mapping/mapping_partitioner.py
+++ b/src/morph_kgc/mapping/mapping_partitioner.py
@@ -338,7 +338,6 @@ class MappingPartitioner:
         self.rml_df['mapping_partition'] = self.rml_df['subject_partition'].astype(str) + '-' + \
             self.rml_df['predicate_partition'].astype(str) + '-' + \
             self.rml_df['object_partition'].astype(str) + '-' + self.rml_df['graph_partition'].astype(str)
-        self.rml_df.sort_values(by='mapping_partition', ascending=False).to_csv('a.csv', index=False)
 
         # drop the auxiliary columns that were created just to generate the mapping partition
         self.rml_df.drop([
@@ -386,14 +385,12 @@ class MappingPartitioner:
                 self.rml_df.at[i, 'object_invariant'] = get_invariant_of_template(str(rml_rule['object_map_value']))
             # elif pd.notna(rml_rule['object_parent_triples_map']) and rml_rule['object_parent_triples_map']!="":
             elif rml_rule['object_map_type'] == RML_PARENT_TRIPLES_MAP:
-
                 # get the invariant for referencing object maps
-                # parent_rml_rule = get_rml_rule(self.rml_df, rml_rule['object_parent_triples_map'])
                 parent_rml_rule = get_rml_rule(self.rml_df, rml_rule['object_map_value'])
 
-                if rml_rule['subject_map_type'] == RML_CONSTANT:
+                if parent_rml_rule['subject_map_type'] == RML_CONSTANT:
                     self.rml_df.at[i, 'object_invariant'] = str(parent_rml_rule['subject_map_value'])
-                elif rml_rule['subject_map_type'] == RML_TEMPLATE:
+                elif parent_rml_rule['subject_map_type'] == RML_TEMPLATE:
                     self.rml_df.at[i, 'object_invariant'] = \
                         get_invariant_of_template(str(parent_rml_rule['subject_map_value']))
 


### PR DESCRIPTION
When processing the mapping graph, complete the referencing object maps with their termtypes. This is relevant when generating the invariants.