### PR TITLE
Morph-kgc integrated with Kafka

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@
 - User-friendly mappings with **[YARRRML](https://rml.io/yarrrml/spec/)**.
 - Transformation functions with **[RML-FNML](https://w3id.org/rml/fnml/spec)**, including **Python user-defined functions**.
 - [RDF-star](https://w3c.github.io/rdf-star/cg-spec/2021-12-17.html) generation with **[RML-star](https://w3id.org/rml/star/spec)**.
-- **[RML views](https://oa.upm.es/73463/1/_2023___ESWC__RML_Tabular_Views.pdf)** over tabular data sources and **[JSON](https://www.json.org)** files.
-- Integration with **[RDFLib](https://rdflib.readthedocs.io)** and **[Oxigraph](https://pyoxigraph.readthedocs.io/en/latest/)**.
+- **[RML views](https://oa.upm.es/73463/1/_2023___ESWC__RML_Tabular_Views.pdf)** over tabular data sources and [JSON](https://www.json.org) files.
+- Integration with **[RDFLib](https://rdflib.readthedocs.io)**, **[Oxigraph](https://pyoxigraph.readthedocs.io/en/latest/)** and **[Kafka](https://kafka-python.readthedocs.io)**.
 - **Optimized** to materialize large knowledge graphs.
 - **Remote** data and mapping files.
 - Input data formats:
@@ -54,7 +54,7 @@ python3 -m morph_kgc config.ini
 
 Check the **[documentation](https://morph-kgc.readthedocs.io/en/latest/documentation/#configuration)** to see how to generate the configuration **INI file**. **[Here](https://github.com/morph-kgc/morph-kgc/blob/main/examples/configuration-file/default_config.ini)** you can also see an example INI file.
 
-It is also possible to run Morph-KGC as a **library** with **[RDFLib](https://rdflib.readthedocs.io)** and **[Oxigraph](https://pyoxigraph.readthedocs.io/en/latest/)**:
+It is also possible to run Morph-KGC as a **library** with **[RDFLib](https://rdflib.readthedocs.io)**, **[Oxigraph](https://pyoxigraph.readthedocs.io/en/latest/)** and **[Kafka](https://kafka-python.readthedocs.io)**:
 ```python
 import morph_kgc
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -42,18 +42,9 @@ To run the engine using the **command line** you just need to execute the follow
 python3 -m morph_kgc path/to/config.ini
 ```
 
-Additionally, if you include the following two variables in your config.ini under the [CONFIGURATION] section:
-
-```ini
-[CONFIGURATION]
-output_kafka_server = "IP:9092"
-output_kafka_topic = "example_topic"
-```
-Morph-KGC will also send the generated triplets to the specified Kafka topic during the materialization process.
-
 ### Library
 
-Morph-KGC can be used as a **library**, providing different methods to materialize the **[RDF](https://www.w3.org/TR/rdf11-concepts/)** or **[RDF-star](https://w3c.github.io/rdf-star/cg-spec/2021-12-17.html)** knowledge graph. It integrates with **[RDFLib](https://rdflib.readthedocs.io/en/stable/)**, **[Oxigraph](https://pyoxigraph.readthedocs.io/en/latest/)** and **[Kafka](https://kafka-python.readthedocs.io/en/master/)** to easily create and work with knowledge graphs in **[Python](https://www.python.org/)**.
+Morph-KGC can be used as a **library**, providing different methods to materialize the **[RDF](https://www.w3.org/TR/rdf11-concepts/)** or **[RDF-star](https://w3c.github.io/rdf-star/cg-spec/2021-12-17.html)** knowledge graph. It integrates with **[RDFLib](https://rdflib.readthedocs.io/en/stable/)**, **[Oxigraph](https://pyoxigraph.readthedocs.io/en/latest/)** and **[Kafka](https://kafka-python.readthedocs.io)** to easily create and work with knowledge graphs in **[Python](https://www.python.org/)**.
 
 The methods in the **API** accept the **config as a string or as the path to an INI file**.
 
@@ -107,27 +98,6 @@ graph = morph_kgc.materialize_oxigraph('/path/to/config.ini')
 q_res = graph.query(' SELECT DISTINCT ?classes WHERE { ?s a ?classes } ')
 ```
 
-#### [Kafka](https://kafka-python.readthedocs.io/en/master/)
-
-**`morph_kgc.materialize_kafka(config)`**
-
-To use this method, ensure your `config.ini` includes two additional variables under the `[CONFIGURATION]` section:
-
-```ini
-[CONFIGURATION]
-output_kafka_server = "IP:9092"
-output_kafka_topic = "example_topic"
-```
-Materialize the knowledge graph and sent to **[Kafka](https://kafka-python.readthedocs.io/en/master/)** topic.
-
-```Python
-# generate the triples and sent them to Kafka topic
-
-graph = morph_kgc.materialize_kafka(config)
-# or
-graph = morph_kgc.materialize_kafka('/path/to/config.ini')
-```
-
 #### Set of Triples
 
 **`morph_kgc.materialize_set(config)`**
@@ -143,6 +113,20 @@ graph = morph_kgc.materialize_set('/path/to/config.ini')
 
 # work with the Python set
 print(len(graph))
+```
+
+#### [Kafka](https://kafka-python.readthedocs.io)
+
+**`morph_kgc.materialize_kafka(config)`**
+
+Materialize the knowledge graph to a **[Kafka](https://kafka-python.readthedocs.io)** topic. To use this method, ensure that the config file includes the `output_kafka_server` and `output_kafka_topic` parameters.
+
+```Python
+# generate the triples and sent them to Kafka topic
+
+graph = morph_kgc.materialize_kafka(config)
+# or
+graph = morph_kgc.materialize_kafka('/path/to/config.ini')
 ```
 
 ## Configuration
@@ -169,8 +153,6 @@ main_dir: ../testing
 
 [CONFIGURATION]
 output_file: knowledge-graph.nt
-output_kafka_server = "IP:9092"
-output_kafka_topic = "example_topic"
 
 [DataSource1]
 mappings: ${mappings_dir}/mapping_file.rml.ttl
@@ -186,9 +168,9 @@ The execution of Morph-KGC can be **tuned** via the **`CONFIGURATION`** section 
 | <div style="width:195px">Property</div> | Description                                                                                                                                                                                                                                  | Values                                                                                                                                                                  |
 |-----------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **`output_file`**                       | File to write the resulting knowledge graph to.                                                                                                                                                                                              | **Default:** _knowledge-graph.nt_                                                                                                                                       |
-| **`output_kafka_server`**              | Kafka server address for sending the resulting knowledge graph.                                                                                                                                                                               | **Default:**                                                                                                                                                            |
-| **`output_kafka_topic`**               | Kafka topic to send the resulting knowledge graph to.                                                                                                                                                                                         | **Default:**                                                                                                                                                            |
 | **`output_dir`**                        | Directory to write the resulting knowledge graph to. If it is specified, `output_file` will be ignored and multiple output files will generated, one for each mapping partition.                                                             | **Default:**                                                                                                                                                            |
+| **`output_kafka_server`**               | Kafka server address for sending the resulting knowledge graph.                                                                                                                                                                              | **Default:**                                                                                                                                                            |
+| **`output_kafka_topic`**                | Kafka topic to send the resulting knowledge graph to.                                                                                                                                                                                        | **Default:**                                                                                                                                                            |
 | **`na_values`**                         | Set of values to be interpreted as _NULL_ when retrieving data from the input sources. The set of values must be separated by commas.                                                                                                        | **Default:** ,_nan_                                                                                                                                                     |
 | **`output_format`**                     | RDF serialization to use for the resulting knowledge graph.                                                                                                                                                                                  | **Valid:** _[N-TRIPLES](https://www.w3.org/TR/n-triples/)_, _[N-QUADS](https://www.w3.org/TR/n-quads/)_<br>**Default:** _[N-TRIPLES](https://www.w3.org/TR/n-triples/)_ |
 | **`only_printable_chars`**              | Remove characters in the genarated RDF that are not printable.                                                                                                                                                                               | **Valid:** _yes_, _no_, _true_, _false_, _on_, _off_, _1_, _0_<br>**Default:** _no_                                                                                     |

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -42,9 +42,18 @@ To run the engine using the **command line** you just need to execute the follow
 python3 -m morph_kgc path/to/config.ini
 ```
 
+Additionally, if you include the following two variables in your config.ini under the [CONFIGURATION] section:
+
+```ini
+[CONFIGURATION]
+output_kafka_server = "IP:9092"
+output_kafka_topic = "example_topic"
+```
+Morph-KGC will also send the generated triplets to the specified Kafka topic during the materialization process.
+
 ### Library
 
-Morph-KGC can be used as a **library**, providing different methods to materialize the **[RDF](https://www.w3.org/TR/rdf11-concepts/)** or **[RDF-star](https://w3c.github.io/rdf-star/cg-spec/2021-12-17.html)** knowledge graph. It integrates with **[RDFLib](https://rdflib.readthedocs.io/en/stable/)** and **[Oxigraph](https://pyoxigraph.readthedocs.io/en/latest/)** to easily create and work with knowledge graphs in **[Python](https://www.python.org/)**.
+Morph-KGC can be used as a **library**, providing different methods to materialize the **[RDF](https://www.w3.org/TR/rdf11-concepts/)** or **[RDF-star](https://w3c.github.io/rdf-star/cg-spec/2021-12-17.html)** knowledge graph. It integrates with **[RDFLib](https://rdflib.readthedocs.io/en/stable/)**, **[Oxigraph](https://pyoxigraph.readthedocs.io/en/latest/)** and **[Kafka](https://kafka-python.readthedocs.io/en/master/)** to easily create and work with knowledge graphs in **[Python](https://www.python.org/)**.
 
 The methods in the **API** accept the **config as a string or as the path to an INI file**.
 
@@ -98,6 +107,27 @@ graph = morph_kgc.materialize_oxigraph('/path/to/config.ini')
 q_res = graph.query(' SELECT DISTINCT ?classes WHERE { ?s a ?classes } ')
 ```
 
+#### [Kafka](https://kafka-python.readthedocs.io/en/master/)
+
+**`morph_kgc.materialize_kafka(config)`**
+
+To use this method, ensure your `config.ini` includes two additional variables under the `[CONFIGURATION]` section:
+
+```ini
+[CONFIGURATION]
+output_kafka_server = "IP:9092"
+output_kafka_topic = "example_topic"
+```
+Materialize the knowledge graph and sent to **[Kafka](https://kafka-python.readthedocs.io/en/master/)** topic.
+
+```Python
+# generate the triples and sent them to Kafka topic
+
+graph = morph_kgc.materialize_kafka(config)
+# or
+graph = morph_kgc.materialize_kafka('/path/to/config.ini')
+```
+
 #### Set of Triples
 
 **`morph_kgc.materialize_set(config)`**
@@ -139,6 +169,8 @@ main_dir: ../testing
 
 [CONFIGURATION]
 output_file: knowledge-graph.nt
+output_kafka_server = "IP:9092"
+output_kafka_topic = "example_topic"
 
 [DataSource1]
 mappings: ${mappings_dir}/mapping_file.rml.ttl
@@ -154,6 +186,8 @@ The execution of Morph-KGC can be **tuned** via the **`CONFIGURATION`** section 
 | <div style="width:195px">Property</div> | Description                                                                                                                                                                                                                                  | Values                                                                                                                                                                  |
 |-----------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **`output_file`**                       | File to write the resulting knowledge graph to.                                                                                                                                                                                              | **Default:** _knowledge-graph.nt_                                                                                                                                       |
+| **`output_kafka_server`**              | Kafka server address for sending the resulting knowledge graph.                                                                                                                                                                               | **Default:**                                                                                                                                                            |
+| **`output_kafka_topic`**               | Kafka topic to send the resulting knowledge graph to.                                                                                                                                                                                         | **Default:**                                                                                                                                                            |
 | **`output_dir`**                        | Directory to write the resulting knowledge graph to. If it is specified, `output_file` will be ignored and multiple output files will generated, one for each mapping partition.                                                             | **Default:**                                                                                                                                                            |
 | **`na_values`**                         | Set of values to be interpreted as _NULL_ when retrieving data from the input sources. The set of values must be separated by commas.                                                                                                        | **Default:** ,_nan_                                                                                                                                                     |
 | **`output_format`**                     | RDF serialization to use for the resulting knowledge graph.                                                                                                                                                                                  | **Valid:** _[N-TRIPLES](https://www.w3.org/TR/n-triples/)_, _[N-QUADS](https://www.w3.org/TR/n-quads/)_<br>**Default:** _[N-TRIPLES](https://www.w3.org/TR/n-triples/)_ |

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,8 +12,8 @@
 - User-friendly mappings with **[YARRRML](https://rml.io/yarrrml/spec/)**.
 - Transformation functions with **[RML-FNML](https://w3id.org/rml/fnml/spec)**, including **Python user-defined functions**.
 - [RDF-star](https://w3c.github.io/rdf-star/cg-spec/2021-12-17.html) generation with **[RML-star](https://w3id.org/rml/star/spec)**.
-- **[RML views](https://oa.upm.es/73463/1/_2023___ESWC__RML_Tabular_Views.pdf)** over tabular data sources and **[JSON](https://www.json.org)** files.
-- Integration with **[RDFLib](https://rdflib.readthedocs.io)** and **[Oxigraph](https://pyoxigraph.readthedocs.io/en/latest/)**.
+- **[RML views](https://oa.upm.es/73463/1/_2023___ESWC__RML_Tabular_Views.pdf)** over tabular data sources and [JSON](https://www.json.org) files.
+- Integration with **[RDFLib](https://rdflib.readthedocs.io)**, **[Oxigraph](https://pyoxigraph.readthedocs.io/en/latest/)** and **[Kafka](https://kafka-python.readthedocs.io)**.
 - **Optimized** to materialize large knowledge graphs.
 - **Remote** data and mapping files.
 - Input data formats:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,7 @@ dependencies = [
   'jsonpath-python>=1.0.6, <2.0.0',
   'elementpath>=4.0.0, <5.0.0',
   'duckdb>=0.7.0, <0.8.0',
-  'falcon>=3.0.0, <4.0.0',
-  'kafka-python>=2.0.2'
+  'falcon>=3.0.0, <4.0.0'
 ]
 
 [tool.hatch.version]
@@ -58,6 +57,7 @@ path = 'src/morph_kgc/_version.py'
 
 [project.optional-dependencies]
 test = ['pytest>=7.0.0, <8.0.0', 'openpyxl>=3.0.0, <4.0.0', 'odfpy>=1.4.1, <2.0.0', 'pyarrow>=11.0.0, <14.0.0']
+kafka = ['kafka-python>=2.0.2, <3.0.0']
 mysql = ['pymysql>=1.0.2, <2.0.0', 'cryptography>=39.0.0, <42.0.0']
 postgresql = ['psycopg[binary]>=3.0.0, <4.0.0']
 oracle = ['cx-Oracle>=8.3.0, <9.0.0']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,8 @@ dependencies = [
   'jsonpath-python>=1.0.6, <2.0.0',
   'elementpath>=4.0.0, <5.0.0',
   'duckdb>=0.7.0, <0.8.0',
-  'falcon>=3.0.0, <4.0.0'
+  'falcon>=3.0.0, <4.0.0',
+  'kafka-python>=2.0.2'
 ]
 
 [tool.hatch.version]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ excel = ['openpyxl>=3.0.0, <4.0.0', 'odfpy>=1.4.1, <2.0.0']
 tabular = ['pyarrow>=11.0.0, <14.0.0']
 spss = ['pyreadstat>=1.2.0, <2.0.0']
 all = [
+  'morph_kgc[kafka]',
   'morph_kgc[mysql]',
   'morph_kgc[postgresql]',
   'morph_kgc[oracle]',

--- a/src/morph_kgc/__init__.py
+++ b/src/morph_kgc/__init__.py
@@ -66,9 +66,8 @@ def materialize(config, python_source=None):
     triples = materialize_set(config, python_source)
 
     graph = Graph()
-    rdf_ntriples = '.\n'.join(triples)
-    if rdf_ntriples:
-        # only add final dot if at least one triple was generated
+    if triples:
+        rdf_ntriples = '.\n'.join(triples)
         rdf_ntriples += '.'
         graph.parse(data=rdf_ntriples, format='nquads')
 
@@ -79,9 +78,8 @@ def materialize_oxigraph(config, python_source=None):
     triples = materialize_set(config, python_source)
 
     graph = Store()
-    rdf_ntriples = '.\n'.join(triples)
-    if rdf_ntriples:
-        # only add final dot if at least one triple was generated
+    if triples:
+        rdf_ntriples = '.\n'.join(triples)
         rdf_ntriples += '.'
         graph.bulk_load(BytesIO(rdf_ntriples.encode()), 'application/n-quads')
 

--- a/src/morph_kgc/__init__.py
+++ b/src/morph_kgc/__init__.py
@@ -15,7 +15,6 @@ from rdflib import Graph
 from pyoxigraph import Store
 from io import BytesIO
 from itertools import repeat
-from kafka import KafkaProducer
 
 from .args_parser import load_config_from_command_line
 from .mapping.mapping_parser import retrieve_mappings
@@ -85,6 +84,8 @@ def materialize_oxigraph(config, python_source=None):
 
 
 def materialize_kafka(config, python_source=None):
+    from kafka import KafkaProducer
+
     kafka_producer = None
 
     try:

--- a/src/morph_kgc/__init__.py
+++ b/src/morph_kgc/__init__.py
@@ -15,6 +15,7 @@ from rdflib import Graph
 from pyoxigraph import Store
 from io import BytesIO
 from itertools import repeat
+from kafka import KafkaProducer
 
 from .args_parser import load_config_from_command_line
 from .mapping.mapping_parser import retrieve_mappings
@@ -85,3 +86,42 @@ def materialize_oxigraph(config, python_source=None):
         graph.bulk_load(BytesIO(rdf_ntriples.encode()), 'application/n-quads')
 
     return graph
+
+
+def materialize_kafka(config, python_source=None):
+    
+    kafka_producer = None
+
+    try:
+    
+        triples = materialize_set(config, python_source)
+        config = load_config_from_argument(config)
+        output_kafka_server = config.get_output_kafka_server().strip('"')
+        output_kafka_topic = config.get_output_kafka_topic().strip('"')
+
+        if not output_kafka_server or not output_kafka_topic:
+            logging.warning('Output Kafka server or topic is empty.')
+            return "Skipping Kafka publishing."
+        
+        kafka_producer = KafkaProducer(bootstrap_servers=output_kafka_server)
+        kafka_producer.send(output_kafka_topic, value=b'RDF triples materialized:')
+        logging.info(f'Connected to Kafka broker at {output_kafka_server}')
+
+        rdf_ntriples = '.\n'.join(triples)
+        if rdf_ntriples:
+            # only add final dot if at least one triple was generated
+            rdf_ntriples += '.'
+
+            # Send the RDF triples to Kafka
+            kafka_producer.send(output_kafka_topic, value=rdf_ntriples.encode('utf-8'))
+
+        logging.info(f'RDF triples materialized and sent to Kafka topic: {output_kafka_topic}.')
+
+        return "Materialization and Kafka publishing complete."
+    except Exception as e:
+            logging.error(f'Error during materialization or Kafka publishing: {e}')
+            return f'Error: {e}'
+    finally:
+        # Close the Kafka producer
+        if kafka_producer:
+            kafka_producer.close()

--- a/src/morph_kgc/__main__.py
+++ b/src/morph_kgc/__main__.py
@@ -39,7 +39,6 @@ if __name__ == "__main__":
 
     start_time = time.time()
     num_triples = 0
-    result = 0
     if config.is_multiprocessing_enabled():
         logging.debug(f'Parallelizing with {config.get_number_of_processes()} cores.')
 

--- a/src/morph_kgc/__main__.py
+++ b/src/morph_kgc/__main__.py
@@ -44,20 +44,20 @@ if __name__ == "__main__":
         logging.debug(f'Parallelizing with {config.get_number_of_processes()} cores.')
 
         pool = mp.Pool(config.get_number_of_processes())
-        num_triples = sum(pool.starmap(_materialize_mapping_group_to_file,
-                                       zip(mapping_groups, repeat(rml_df), repeat(fnml_df), repeat(config))))
-        result = sum(pool.starmap(_materialize_mapping_group_to_kafka,
-                                       zip(mapping_groups, repeat(rml_df), repeat(fnml_df), repeat(config))))
+        if not config.get_output_kafka_server():
+            num_triples = sum(pool.starmap(_materialize_mapping_group_to_file,
+                                           zip(mapping_groups, repeat(rml_df), repeat(fnml_df), repeat(config))))
+        else:
+            num_triples = sum(pool.starmap(_materialize_mapping_group_to_kafka,
+                                           zip(mapping_groups, repeat(rml_df), repeat(fnml_df), repeat(config))))
         pool.close()
         pool.join()
     else:
         for mapping_group in mapping_groups:
-            num_triples += _materialize_mapping_group_to_file(mapping_group, rml_df, fnml_df, config)
-            result += _materialize_mapping_group_to_kafka(mapping_group, rml_df, fnml_df, config)
+            if not config.get_output_kafka_server():
+                num_triples += _materialize_mapping_group_to_file(mapping_group, rml_df, fnml_df, config)
+            else:
+                num_triples += _materialize_mapping_group_to_kafka(mapping_group, rml_df, fnml_df, config)
 
     logging.info(f'Number of triples generated in total: {num_triples}.')
     logging.info(f'Materialization finished in {get_delta_time(start_time)} seconds.')
-    if result == 0:
-        logging.info(f'RDF triples materialized and sent to Kafka topic.')
-    else:
-        logging.info(f'Output Kafka server or topic is empty. Skipping Kafka publishing.')

--- a/src/morph_kgc/config.py
+++ b/src/morph_kgc/config.py
@@ -113,7 +113,7 @@ CONFIGURATION_OPTIONS_EMPTY_VALID = {
             OUTPUT_KAFKA_TOPIC: DEFAULT_OUTPUT_KAFKA_TOPIC,
         }
 
-# input parameters that are to be replaced with the default vale if they are empty
+# input parameters that are to be replaced with the default value if they are empty
 CONFIGURATION_OPTIONS_EMPTY_NON_VALID = {
             OUTPUT_DIR: DEFAULT_OUTPUT_DIR,
             OUTPUT_FORMAT: DEFAULT_OUTPUT_FORMAT,

--- a/src/morph_kgc/config.py
+++ b/src/morph_kgc/config.py
@@ -60,6 +60,11 @@ FILE_PATH = 'file_path'
 DATABASE_URL = 'db_url'
 CONNECT_ARGS = 'connect_args'
 
+##############################################################################
+##########################  KAFKA PARAMETERS  ################################
+##############################################################################
+OUTPUT_KAFKA_SERVER = 'output_kafka_server'
+OUTPUT_KAFKA_TOPIC = 'output_kafka_topic'
 
 ##############################################################################
 ########################   ARGUMENTS DEFAULT VALUES   ########################
@@ -76,6 +81,8 @@ DEFAULT_NUMBER_OF_PROCESSES = 2 * mp.cpu_count()
 DEFAULT_NA_VALUES = ',nan' # ',#N/A,N/A,#N/A N/A,n/a,NA,<NA>,#NA,NULL,null,NaN,nan,None'
 DEFAULT_ONLY_PRINTABLE_CHARS = 'no'
 DEFAULT_UDFS = ''
+DEFAULT_OUTPUT_KAFKA_SERVER = ''
+DEFAULT_OUTPUT_KAFKA_TOPIC = ''
 
 # ORACLE
 DEFAULT_ORACLE_CLIENT_LIB_DIR = ''
@@ -102,6 +109,8 @@ CONFIGURATION_OPTIONS_EMPTY_VALID = {
             ORACLE_CLIENT_LIB_DIR: DEFAULT_ORACLE_CLIENT_LIB_DIR,
             ORACLE_CLIENT_CONFIG_DIR: DEFAULT_ORACLE_CLIENT_LIB_DIR,
             UDFS: DEFAULT_UDFS,
+            OUTPUT_KAFKA_SERVER: DEFAULT_OUTPUT_KAFKA_SERVER,
+            OUTPUT_KAFKA_TOPIC: DEFAULT_OUTPUT_KAFKA_TOPIC,
         }
 
 # input parameters that are to be replaced with the default vale if they are empty
@@ -287,6 +296,12 @@ class Config(ConfigParser):
 
         return file_path.as_posix()
 
+    def get_output_kafka_server(self):
+        return self.get(self.configuration_section, OUTPUT_KAFKA_SERVER)
+
+    def get_output_kafka_topic(self):
+        return self.get(self.configuration_section, OUTPUT_KAFKA_TOPIC)
+    
     def set_mapping_partitioning(self, mapping_partitioning):
         self.set(self.configuration_section, MAPPING_PARTITIONING, mapping_partitioning.upper())
 

--- a/src/morph_kgc/materializer.py
+++ b/src/morph_kgc/materializer.py
@@ -436,3 +436,17 @@ def _materialize_mapping_group_to_set(mapping_group_df, rml_df, fnml_df, config,
         triples.update(set(data['triple']))
 
     return triples
+
+def _materialize_mapping_group_to_kafka(mapping_group_df, rml_df, fnml_df, config, python_source=None):
+
+    triples = set()
+    for i, rml_rule in mapping_group_df.iterrows():
+        start_time = time.time()
+        data = _materialize_rml_rule(rml_rule, rml_df, fnml_df, config, python_source=python_source)
+        triples.update(set(data['triple']))
+
+        logging.debug(f"{len(triples)} triples generated for mapping rule `{rml_rule['triples_map_id']}` "
+                      f"in {get_delta_time(start_time)} seconds.")
+        
+    result = triples_to_kafka(triples, config)
+    return result

--- a/src/morph_kgc/materializer.py
+++ b/src/morph_kgc/materializer.py
@@ -412,8 +412,16 @@ def _materialize_rml_rule(rml_rule, rml_df, fnml_df, config, data=None, parent_j
     return data
 
 
-def _materialize_mapping_group_to_file(mapping_group_df, rml_df, fnml_df, config):
+def _materialize_mapping_group_to_set(mapping_group_df, rml_df, fnml_df, config, python_source=None):
+    triples = set()
+    for i, rml_rule in mapping_group_df.iterrows():
+        data = _materialize_rml_rule(rml_rule, rml_df, fnml_df, config, python_source=python_source)
+        triples.update(set(data['triple']))
 
+    return triples
+
+
+def _materialize_mapping_group_to_file(mapping_group_df, rml_df, fnml_df, config):
     triples = set()
     for i, rml_rule in mapping_group_df.iterrows():
         start_time = time.time()
@@ -428,17 +436,7 @@ def _materialize_mapping_group_to_file(mapping_group_df, rml_df, fnml_df, config
     return len(triples)
 
 
-def _materialize_mapping_group_to_set(mapping_group_df, rml_df, fnml_df, config, python_source=None):
-
-    triples = set()
-    for i, rml_rule in mapping_group_df.iterrows():
-        data = _materialize_rml_rule(rml_rule, rml_df, fnml_df, config, python_source=python_source)
-        triples.update(set(data['triple']))
-
-    return triples
-
 def _materialize_mapping_group_to_kafka(mapping_group_df, rml_df, fnml_df, config, python_source=None):
-
     triples = set()
     for i, rml_rule in mapping_group_df.iterrows():
         start_time = time.time()
@@ -448,5 +446,6 @@ def _materialize_mapping_group_to_kafka(mapping_group_df, rml_df, fnml_df, confi
         logging.debug(f"{len(triples)} triples generated for mapping rule `{rml_rule['triples_map_id']}` "
                       f"in {get_delta_time(start_time)} seconds.")
         
-    result = triples_to_kafka(triples, config)
-    return result
+    triples_to_kafka(triples, config)
+
+    return len(triples)

--- a/src/morph_kgc/utils.py
+++ b/src/morph_kgc/utils.py
@@ -17,7 +17,6 @@ import numpy as np
 import pandas as pd
 import multiprocessing as mp
 
-from kafka import KafkaProducer
 from itertools import product
 from .constants import AUXILIAR_UNIQUE_REPLACING_STRING, RML_EXECUTION, RML_TEMPLATE, RML_REFERENCE
 
@@ -284,6 +283,8 @@ def triples_to_kafka(triples, config):
     """
     Writes triples to Kafka.
     """
+    from kafka import KafkaProducer
+
     kafka_producer = None
     output_kafka_server = config.get_output_kafka_server()
     output_kafka_topic = config.get_output_kafka_topic()


### PR DESCRIPTION
This pull request is centered around a pivotal enhancement: the seamless integration of Morph-KGC with Kafka. The core objective is to fortify Morph-KGC's capabilities, enabling users to effortlessly materialize and dispatch knowledge graphs to Kafka topics. The key updates include:

Configuration Update:
Extended config.ini to recognize two new variables: server and topic.

Library Functionality:
Added a new method in the initialization (__init__.py) to materialize triplets and send them to the Kafka topic, facilitating usage as a library.

Command-Line Enhancements:
Introduced two new functions, one in materialize.py utilizing a utility function from utils, for sending triplets to the Kafka topic. Main execution now includes the function to send triplets to the Kafka topic if both the server and topic are configured in config.ini.

Documentation has been revised to reflect these updates.

These changes offer improved configurability and usage options for Morph-KGC, catering to both library integration and command-line execution scenarios.