### PR TITLE
Docker Containerization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.9-slim as python-base
+
+# Install necessary system dependencies
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+        curl \
+        build-essential
+        
+################################
+# BUILDER-BASE
+# Used to build deps + create our virtual environment
+################################
+FROM python-base as builder-base
+RUN pip install hatch
+ENV PYSETUP_PATH="/opt/pysetup" \
+    VENV_PATH="/opt/pysetup/.venv"
+
+COPY pyproject.toml ./
+ARG optional_dependencies
+
+RUN hatch dep show requirements >> requirements.txt
+RUN python -m pip install -r requirements.txt
+
+RUN echo '#!/bin/bash\n\
+    IFS=',' read -ra optional_dependencies <<< "$1"\n\
+    for DEP in "${optional_dependencies[@]}"; do\n\
+        hatch dep show requirements --feature "$DEP" >> requirements_optional.txt\n\
+    done\n\
+    python -m pip install -r requirements_optional.txt' > create_and_install_optional_requirements.sh
+
+RUN chmod +x create_and_install_optional_requirements.sh
+RUN ./create_and_install_optional_requirements.sh "$optional_dependencies"
+
+
+################################
+# PRODUCTION
+# Final image used for runtime
+################################
+FROM python-base as production
+COPY --from=builder-base $PYSETUP_PATH $PYSETUP_PATH
+COPY ./src /app
+WORKDIR /app
+ENTRYPOINT ["python", "-m", "morph_kgc"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,15 +23,18 @@ ARG optional_dependencies
 RUN hatch dep show requirements >> requirements.txt
 RUN python -m pip install -r requirements.txt
 
-RUN echo '#!/bin/bash\n\
-    IFS=',' read -ra optional_dependencies <<< "$1"\n\
-    for DEP in "${optional_dependencies[@]}"; do\n\
-        hatch dep show requirements --feature "$DEP" >> requirements_optional.txt\n\
-    done\n\
-    python -m pip install -r requirements_optional.txt' > create_and_install_optional_requirements.sh
-
-RUN chmod +x create_and_install_optional_requirements.sh
-RUN ./create_and_install_optional_requirements.sh "$optional_dependencies"
+RUN if [ -n "$optional_dependencies" ]; then \
+        echo '#!/bin/bash\n\
+            IFS=',' read -ra optional_dependencies <<< "$1"\n\
+            for DEP in "${optional_dependencies[@]}"; do\n\
+                hatch dep show requirements --feature "$DEP" >> requirements_optional.txt\n\
+            done\n\
+            python -m pip install -r requirements_optional.txt' > create_and_install_optional_requirements.sh; \
+        chmod +x create_and_install_optional_requirements.sh; \
+        ./create_and_install_optional_requirements.sh "$optional_dependencies"; \
+    else \
+        echo "No optional dependencies specified."; \
+    fi
 
 
 ################################

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ g_rdflib = morph_kgc.materialize(config)
 
 We've added a Dockerfile to simplify the containerization of Morph-KGC. This allows you to package the application with all its dependencies into a self-contained Docker container.
 
-### Optional Dependencies
+### Image Building
 
 You can specify optional dependencies during the container build process using the `optional_dependencies` argument. Simply provide a comma-separated list of the dependencies you wish to include. For example:
 
@@ -93,7 +93,7 @@ To include optional dependencies, use for example:
 docker build -t morph-kgc-app --build-arg optional_dependencies="sqlite,kafka" .
 ```
 
-## Docker Containerization
+## Docker execution
 The container is designed to mount a local directory containing the required files. To run the container, use the following command, replacing $(pwd)/files with the path to the local directory containing your files:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -76,6 +76,31 @@ config = """
          """
 g_rdflib = morph_kgc.materialize(config)
 ```
+## Docker Containerization
+
+We've added a Dockerfile to simplify the containerization of Morph-KGC. This allows you to package the application with all its dependencies into a self-contained Docker container.
+
+### Optional Dependencies
+
+You can specify optional dependencies during the container build process using the `optional_dependencies` argument. Simply provide a comma-separated list of the dependencies you wish to include. For example:
+
+```bash
+docker build -t morph-kgc-app .
+```
+
+To include optional dependencies, use for example:
+```bash
+docker build -t morph-kgc-app --build-arg optional_dependencies="sqlite,kafka" .
+```
+
+## Docker Containerization
+The container is designed to mount a local directory containing the required files. To run the container, use the following command, replacing $(pwd)/files with the path to the local directory containing your files:
+
+```bash
+docker run -v $(pwd)/files:/app/files morph-kgc-app files/config.ini
+```
+
+This will mount the local directory to /app/files within the container and execute the application using the provided config.ini file.
 
 ## License :unlock:
 

--- a/README.md
+++ b/README.md
@@ -85,19 +85,19 @@ We've added a Dockerfile to simplify the containerization of Morph-KGC. This all
 You can specify optional dependencies during the container build process using the `optional_dependencies` argument. Simply provide a comma-separated list of the dependencies you wish to include. For example:
 
 ```bash
-docker build -t morph-kgc-app .
+docker build -t morph-kgc .
 ```
 
 To include optional dependencies, use for example:
 ```bash
-docker build -t morph-kgc-app --build-arg optional_dependencies="sqlite,kafka" .
+docker build -t morph-kgc --build-arg optional_dependencies="sqlite,kafka" .
 ```
 
-## Docker execution
+### Docker execution
 The container is designed to mount a local directory containing the required files. To run the container, use the following command, replacing $(pwd)/files with the path to the local directory containing your files:
 
 ```bash
-docker run -v $(pwd)/files:/app/files morph-kgc-app files/config.ini
+docker run -v $(pwd)/files:/app/files morph-kgc files/config.ini
 ```
 
 This will mount the local directory to /app/files within the container and execute the application using the provided config.ini file.


### PR DESCRIPTION
This pull request introduces:

**Docker Containerization:**

- Added a Dockerfile for Morph-KGC to facilitate containerization.

- Optional dependencies can be specified during the build process.

Example usage:

`docker build -t morph-kgc .`

`docker build -t morph-kgc --build-arg optional_dependencies="sqlite,kafka" .`

The container is designed to mount a local directory for required files.

`docker run -v $(pwd)/files:/app/files morph-kgc files/config.ini`

Please review and merge at your convenience.