### PR TITLE
Helm

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+name: morph-kgc
+description: A Helm chart for Kubernetes
+type: application
+version: 1.0.0

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,0 +1,46 @@
+## Morph-KGC Helm Deployment
+
+### Overview
+This directory contains Helm charts for deploying Morph-KGC on Kubernetes. 
+
+### Features
+**Flexible Deployment Options:** Choose between deploying with a CronJob at specified intervals or as a one-time deployment. 
+
+- To enable deployment with specified intervals, modify the cronJob.enabled parameter to true and set the desired schedule. For example, to deploy every minute:
+
+```
+cronJob:
+  enabled: true
+  schedule: "* * * * *"
+```
+In this example:
+- The first asterisk represents minutes and * means "every minute".
+- The second asterisk represents hours and * means "every hour".
+- The third asterisk represents days of the month and * means "every day".
+- The fourth asterisk represents months and * means "every month".
+- The fifth asterisk represents days of the week and * means "every day of the week".
+
+**ConfigMap Integration:** Ensures that the config.ini and mapping.rml.ttl files are treated as ConfigMaps, with names specified in values.yaml.
+
+Users can manually create ConfigMaps using: 
+
+`kubectl create configmap configmap-config --from-file=files/config.ini`
+
+
+**File Mounting Configuration:** 
+The configuration includes automatic mounting of files in the container:
+
+- config.ini is mounted at `/app/config`.
+- The mapping file is mounted at `/app/config/files`.
+
+**Note:** Ensure that the config.ini file contains references to the mapping file starting with `config/files/`.
+
+
+
+## Installation
+
+To install Morph-KGC, use the following command:
+
+```bash
+helm install morph-kgc ./helm
+```

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,0 +1,69 @@
+{{- if .Values.cronJob.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Values.name }}
+  labels:
+    app: {{ .Values.name }}
+spec:
+  schedule: "{{ .Values.cronJob.schedule }}"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: {{ .Values.name }}
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              args:
+                - {{ .Values.morph_kgc_config }}
+              volumeMounts:
+                - name: config-volume-config
+                  mountPath: /app/config
+                - name: config-volume-mapping
+                  mountPath: /app/config/files
+          imagePullSecrets:
+            - name: registry-credentials
+          volumes:
+            - name: config-volume-mapping
+              configMap:
+                name: {{ .Values.configmap_mapping }}
+            - name: config-volume-config
+              configMap:
+                name: {{ .Values.configmap_config }}
+          restartPolicy: OnFailure           
+{{- else }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Values.name }}
+  labels:
+    app: {{ .Values.name }}
+spec:
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.name }}
+    spec:
+      containers:
+        - name: {{ .Values.name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - {{ .Values.morph_kgc_config }}
+          volumeMounts:
+            - name: config-volume-config
+              mountPath: /app/config
+            - name: config-volume-mapping
+              mountPath: /app/config/files
+      imagePullSecrets:
+        - name: registry-credentials
+      volumes:
+        - name: config-volume-mapping
+          configMap:
+            name: {{ .Values.configmap_mapping }}
+        - name: config-volume-config
+          configMap:
+            name: {{ .Values.configmap_config }}
+      restartPolicy: OnFailure
+{{- end }}

--- a/helm/templates/secrets.yaml
+++ b/helm/templates/secrets.yaml
@@ -1,0 +1,10 @@
+# secrets.yaml
+{{- if .Values.dockerConfigJson }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: registry-credentials
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ .Values.dockerConfigJson | b64enc | quote }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,15 @@
+name: morph-kgc
+
+morph_kgc_config: config/config.ini
+configmap_config: configmap-config
+configmap_mapping: configmap-mapping
+
+image:
+  repository: morph-kgc
+  tag: latest
+  pullPolicy: IfNotPresent
+
+cronJob:
+  enabled: false
+  schedule: "* * * * *"
+


### PR DESCRIPTION
**Changes Made:**

- Added Helm for implementation in Kubernetes, enabling streamlined deployment.

- Implemented the option to deploy either with a CronJob at specified intervals or as a one-time deployment. Users have the flexibility to choose between a one-time deployment or scheduling deployments with a CronJob.

- Ensured that the _config.ini_ and _mapping.rml.ttl_ files are each treated as a ConfigMap, with names specified in values.yaml.

- Users can create the ConfigMaps manually using `kubectl create configmap configmap-config --from-file=files/config.ini.`

- Configured file mounting in the container, with _config.ini_ mounted at /app/config and the mapping file at /app/config/files.

- Ensured that the _config.ini_ file contains references to the mapping file starting with config/files/.

- To install it, you can use `helm install morph-kgc ./helm`

Please review and merge at your convenience.