### PR TITLE
Small fix for the documentation link in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 ## Documentation :bookmark_tabs:
 
-**[Read the documentation](https://morph-kgc.readthedocs.io/endocumentation/)**.
+**[Read the documentation](https://morph-kgc.readthedocs.io/)**.
 
 ## Tutorial :woman_teacher:
 


### PR DESCRIPTION
Hi,

just a super small change, the old link lead to a broken webpage. Tested on chromium and firefox. Thanks for the great work!

(Sorry for two commits, still new to contributing)

Kind regards,
Christoph
