### PR TITLE
Documentation: Adding Postgres Example

### DIFF
--- a/examples/postgres/config.ini
+++ b/examples/postgres/config.ini
@@ -1,0 +1,3 @@
+[DataSource]
+mappings: examples/postgres/mapping.ttl
+db_url: postgresql+psycopg://{username}:{password}@{host}:{port}/{database}

--- a/examples/postgres/mapping.ttl
+++ b/examples/postgres/mapping.ttl
@@ -1,0 +1,22 @@
+@prefix rml: <http://w3id.org/rml/> .
+@prefix ex: <http://example.org/ex#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+
+<triples_map> a rml:TriplesMap;
+
+    rml:logicalSource [
+        a rml:LogicalSource;
+        rr:sqlVersion rr:SQL2008;
+        rr:tableName "postgres_tablename";
+    ];
+
+    rml:subjectMap [
+        rml:template "http://example.org/ex#{id}"
+    ];
+
+    rml:predicateObjectMap [
+        rml:predicate dcterms:identifier  ;
+        rml:objectMap [ rml:reference "id" ]
+    ];
+.


### PR DESCRIPTION
This Pull Request adds a basic example on how to set a postgres database as the [Logical Source](https://kg-construct.github.io/rml-io/spec/docs/#logical-source-in-rml) for your RML Mapping using morph-kgc