### PR TITLE
Documentation: Adding Parquet on S3 Example

### DIFF
--- a/examples/s3_parquet/config.ini
+++ b/examples/s3_parquet/config.ini
@@ -1,0 +1,3 @@
+[DataSource]
+mappings: examples/s3_parquet/mapping.ttl
+file_path: s3://mybucket/mydata.parquet

--- a/examples/s3_parquet/mapping.ttl
+++ b/examples/s3_parquet/mapping.ttl
@@ -1,0 +1,21 @@
+@prefix rml: <http://w3id.org/rml/> .
+@prefix ex: <http://example.org/ex#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+
+<triples_map> a rml:TriplesMap;
+
+    rml:logicalSource [
+        a rml:LogicalSource;
+        rr:sqlVersion rr:SQL2008;
+    ];
+
+    rml:subjectMap [
+        rml:template "http://example.org/ex#{id}"
+    ];
+
+    rml:predicateObjectMap [
+        rml:predicate dcterms:identifier  ;
+        rml:objectMap [ rml:reference "id" ]
+    ];
+.


### PR DESCRIPTION
This Pull Request adds a basic example on how to set a parquet file on S3 as the [Logical Source](https://kg-construct.github.io/rml-io/spec/docs/#logical-source-in-rml) for your RML Mapping using morph-kgc