### PR TITLE
loosen ruamel.yaml pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
   'pandas>=2.1.0, <3.0.0',
   'rdflib>=6.1.1, <8.0.0',
   'pyoxigraph>=0.3.0, <0.4.0',
-  'ruamel.yaml==0.18.0, <0.19.0',
+  'ruamel.yaml>=0.18.0, <0.19.0',
   'jsonpath-python>=1.0.6, <2.0.0',
   'elementpath>=4.0.0, <5.0.0',
   'duckdb>=0.10.0, <2.0.0',


### PR DESCRIPTION
Thanks for this tool!

This PR loosens the pin on `ruamel.yaml` to take advantage of bug fixes between `0.18.0` and the latest (`0.18.6`).

Background: in looking to address #153, re-packaging for [conda-forge](https://github.com/conda-forge/staged-recipes/pull/27298) revealed this unexpected dependency limitation.