### PR TITLE
Fix for Abbreviated YARRRML Function Syntax

### DIFF
--- a/src/morph_kgc/mapping/yarrrml.py
+++ b/src/morph_kgc/mapping/yarrrml.py
@@ -267,7 +267,7 @@ def _normalize_function_parameters(term_map):
                 if type(term_map['parameters'][i]['value']) is dict and 'function' in term_map['parameters'][i]['value']:
                     #term_map['parameters'][i]['parameter'] = term_map['parameters'][i]['parameter']
                     term_map['parameters'][i]['value'] = _normalize_function_parameters(term_map['parameters'][i]['value'])
-    elif type(term_map) is str and term_map['function'].endswith(')'):
+    elif type(term_map) is dict and 'function' in term_map and term_map['function'].endswith(')'):
         # inline function examples 99 & 101 YARRRML spec
         inline_function = term_map['function']
         function_id = inline_function.split('(')[0]

--- a/test/rml-fnml/abbreviated_syntax/cars.csv
+++ b/test/rml-fnml/abbreviated_syntax/cars.csv
@@ -1,0 +1,3 @@
+ID,Comment,Seats,Owner,Color,Year,Model
+1,"A red car with 4 seats",4,9,Red,2020,Toyota Corolla
+2,"A blue car with 5 seats",5,8,Blue,2019,Honda Civic

--- a/test/rml-fnml/abbreviated_syntax/mapping.yarrrml
+++ b/test/rml-fnml/abbreviated_syntax/mapping.yarrrml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://rdmr.eu/yarrrml-json-schema/yarrrml-json-schema.json
+prefixes:
+  ex: http://example.com#
+  grel: http://users.ugent.be/~bjdmeest/function/grel.ttl#
+mappings:
+  cars:
+    sources:
+      - access: cars.csv
+        referenceFormulation: csv
+    subjects: ex:car_$(ID)
+    po:
+      - p: ex:model
+        o:
+          function: grel:string_split(valueParameter = $(Model), p_string_sep = ' ')
+          language: en
+      - p: ex:seats
+        o:
+          value: $(Seats)
+          datatype: xsd:integer
+      - p: ex:registrationYear
+        o:
+          value: $(Year)
+          datatype: xsd:gYear
+      - predicates: ex:color
+        objects:
+          type: iri
+          function: grel:toLowerCase(grel:valueParameter = ex:color_$(Color))
+      - predicates: rdf:type
+        objects: ex:Car

--- a/test/rml-fnml/abbreviated_syntax/test_short_functions.py
+++ b/test/rml-fnml/abbreviated_syntax/test_short_functions.py
@@ -1,0 +1,20 @@
+__author__ = "Achim Reiz"
+__credits__ = ["Achim Reiz"]
+
+__license__ = "Apache-2.0"
+__maintainer__ = "Achim Reiz"
+__email__ = "achim.reiz@neonto.de"
+
+
+import os
+import rdflib
+import rdflib.compare
+from morph_kgc import materialize
+
+def test_short_functions():    
+    mapping_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'mapping.yarrrml')
+    csv_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'cars.csv')
+    config = f'[DataSource]\nmappings:{mapping_path}\nfile_path:{csv_path}'
+    rml_morph = materialize(config)
+    assert len(rml_morph) > 2
+    


### PR DESCRIPTION
I had running the abbreviated YARRRML-Function syntax.

```yaml
prefixes:
  ex: http://example.com#
  grel: http://users.ugent.be/~bjdmeest/function/grel.ttl#
mappings:
  cars:
    sources:
      - access: cars.csv
        referenceFormulation: csv
    subjects: http://example.com#car_$(ID)
    po:
      - p: ex:model
        o:
          function: grel:string_split(valueParameter = $(Model), p_string_sep = ' ')
          language: en
```

The first issue was a missmatch in the evaluation for the abbreviated function. It is always a dict for me - the evaluation also has a contradiction - if it is a `str` like evaluated, then `term_map[function]` does not exist.

The second problem was that when the function_id.split is carried out, the prefix syntax is already resolved - thus, the function_id contains `http://users.ugent.be/~bjdmeest/function/grel.ttl#string_split`, not `grel:string_split`. Thus, the function appended `http:` instead of `grel:`

```python
input_parameter = f"{function_id.split(':')[0]}:{input_parameter}"
```

That originated in a little bit larger changes - I kept the prefixes as a separate variable until `_normalize_function_parameters` to resolve the abbreviated form. 