### PR TITLE
Fix url in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To run the engine via **command line** you just need to execute the following:
 python3 -m morph_kgc config.ini
 ```
 
-Check the **[documentation](https://morph-kgc.readthedocs.io/endocumentation/#configuration)** to see how to generate the configuration **INI file**. **[Here](https://github.com/morph-kgc/morph-kgc/blob/main/examples/configuration-file/default_config.ini)** you can also see an example INI file.
+Check the **[documentation](https://morph-kgc.readthedocs.io/en/stable/documentation/#configuration)** to see how to generate the configuration **INI file**. **[Here](https://github.com/morph-kgc/morph-kgc/blob/main/examples/configuration-file/default_config.ini)** you can also see an example INI file.
 
 It is also possible to run Morph-KGC as a **library** with **[RDFLib](https://rdflib.readthedocs.io)** and **[Oxigraph](https://pyoxigraph.readthedocs.io/en)**:
 ```python


### PR DESCRIPTION
Fixed a link in the readme that was not pointing correctly to the online documentation.