### PR TITLE
Install option morph-kgc[http]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,4 +82,5 @@ all = [
   'morph_kgc[neo4j]',
   'morph_kgc[snowflake]',
   'morph_kgc[databricks]',
+  'morph_kgc[http]',
 ]


### PR DESCRIPTION
The HTTP API request install options installs the  [`requests`](https://requests.readthedocs.io/en/latest/) dependency.