### PR TITLE
Extension: JSONPath filter expressions support and null fixed in http_api

### DIFF
--- a/src/morph_kgc/data_source/http_api.py
+++ b/src/morph_kgc/data_source/http_api.py
@@ -6,8 +6,9 @@ __maintainer__ = "Julián Arenas-Guerrero"
 __email__ = "arenas.guerrero.julian@outlook.com"
 
 
+import json
+import urllib.request
 import pandas as pd
-import os
 
 from jsonpath import JSONPath
 from io import StringIO
@@ -24,27 +25,49 @@ def get_http_api_data(config, rml_rule, references):
     headers = {}
     if 'field_name' in df.columns:
         for i, row in df.iterrows():
-            # use env variables for parameterizing HTTP headers
             if row['field_name'].lower() in ['authorization', 'accept', 'keyid', 'user-agent']:
-                headers[row['field_name']] = row['field_value'].format(**os.environ)
+                headers[row['field_name']] = row['field_value']
             else:
-                payload[row['field_name']] = row['field_value'].format(**os.environ)
+                payload[row['field_name']] = row['field_value']
     json_data = requests.get(absolute_path, params=payload, headers=headers).json()
+
+    # Check if any of the references have a JSONPath filter; it's treated differently.
+    # e.g [ rml:predicate sdmx-dimension:ageSemiintervals ; rml:objectMap [ rml:reference "MetaData[?(@.Variable.Id==357)].Nombre" ] ]
+    def has_filter(ref: str) -> bool:
+        return '[?(' in ref
+
+    simple_refs = [r for r in references if not has_filter(r)]
+    filter_refs = [r for r in references if has_filter(r)]
 
     jsonpath_expression = rml_rule['iterator'] + '.('
     # add top level object of the references to reduce intermediate results (THIS IS NOT STRICTLY NECESSARY)
-    for reference in references:
+    for i, reference in enumerate(simple_refs):
         jsonpath_expression += reference.split('.')[0] + ','
+        #jsonpath_expression += reference + ','
     jsonpath_expression = jsonpath_expression[:-1] + ')'
 
     jsonpath_result = JSONPath(jsonpath_expression).parse(json_data)
+
     # normalize and remove nulls
     json_df = pd.json_normalize([json_object for json_object in normalize_hierarchical_data(jsonpath_result) if
                                  None not in json_object.values()])
+    if filter_refs:
+        # Given a filter reference like "MetaData[?(@.Variable.Id==357)].Nombre" we need to convert it to "MetaData[?(@.Variable.Id==357)].(Nombre)"
+        last_field = filter_refs[0][filter_refs[0].rfind('.') + 1:] 
+        filter = filter_refs[0][:filter_refs[0].rfind('.') + 1] + f"({last_field})"
+
+        # same as above but for filtered references
+        jsonpath_result_filters = JSONPath(rml_rule['iterator'] + "." + filter).parse(json_data)
+        flat_filters = pd.json_normalize([json_object for json_object in normalize_hierarchical_data(jsonpath_result_filters) if
+                                 None not in json_object.values()])
+        
+        # add the filtered column to the main dataframe
+        json_df[filter_refs[0]] = flat_filters
 
     # add columns with null values for those references in the mapping rule that are not present in the data file
     missing_references_in_df = list(set(references).difference(set(json_df.columns)))
     json_df[missing_references_in_df] = None
-    json_df.dropna(axis=0, how='any', inplace=True)
+    #json_df.dropna(axis=1, how='any', inplace=True) #This removes everything if threres a null; it should only keep the columns that are in the reference and remove the rest.
+    json_df = json_df[[c for c in references if c in json_df.columns]] #Take only the columns that are in the references.
 
     return json_df


### PR DESCRIPTION
http_api.py extension to support the use of JSONPath filter expressions in rml:reference. 
Also patched bug where rows where deleted from json_df if null values appeared in some colummns, even if they were not supposed to be retreated.