### PR TITLE
Use env variables for credentials in config

### DIFF
--- a/src/morph_kgc/config.py
+++ b/src/morph_kgc/config.py
@@ -342,7 +342,7 @@ class Config(ConfigParser):
         return mapping_file_paths
 
     def get_db_url(self, source_section):
-        return self.get(source_section, DB_URL)
+        return self.get(source_section, DB_URL).format(**os.environ)
 
     def has_db_url(self, source_section):
         return self.has_option(source_section, DB_URL)

--- a/src/morph_kgc/data_source/http_api.py
+++ b/src/morph_kgc/data_source/http_api.py
@@ -9,6 +9,7 @@ __email__ = "arenas.guerrero.julian@outlook.com"
 import json
 import urllib.request
 import pandas as pd
+import os
 
 from jsonpath import JSONPath
 from io import StringIO
@@ -25,10 +26,11 @@ def get_http_api_data(config, rml_rule, references):
     headers = {}
     if 'field_name' in df.columns:
         for i, row in df.iterrows():
+            # use env variables for parameterizing HTTP headers
             if row['field_name'].lower() in ['authorization', 'accept', 'keyid', 'user-agent']:
-                headers[row['field_name']] = row['field_value']
+                headers[row['field_name']] = row['field_value'].format(**os.environ)
             else:
-                payload[row['field_name']] = row['field_value']
+                payload[row['field_name']] = row['field_value'].format(**os.environ)
     json_data = requests.get(absolute_path, params=payload, headers=headers).json()
 
     # Check if any of the references have a JSONPath filter; it's treated differently.


### PR DESCRIPTION
Use `{` `}` to resolve env variables in `db_url`:

```ini
[DataSource1]
mappings=/path/to/mapping/mapping_file.rml.ttl
db_url={env_db_url}
```

Fix #331.