### PR TITLE
Support for dynamic api_token resolution

### DIFF
--- a/examples/dynamic_api_token.py
+++ b/examples/dynamic_api_token.py
@@ -1,0 +1,60 @@
+import json, os, tempfile
+from datetime import datetime
+
+def is_api_token_applicable(token):
+    # Checks whether the token is within a predefined list of valid tokens
+    return token in ["AUTH_TOKEN"]
+
+def atomic_write_json(path, data):
+    if not os.path.exists(path):
+        with open(path, "a"):
+            pass
+
+    dir_name = os.path.dirname(os.path.abspath(path)) or "."
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, prefix=".tmp_", suffix=".json")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        # Atomic replace across platforms (renaming a file is atomic)
+        os.replace(tmp_path, path)
+    finally:
+        # If something failed before replace, clean up
+        if os.path.exists(tmp_path):
+            try: os.remove(tmp_path)
+            except: pass
+
+def safe_read_json(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+def refreshToken(username, password, token_name):
+    # Implementation-specific logic to retrieve a new token
+    return 'SOME_VALUE', 10 # value, exp_time
+
+def get_api_token(token_name):
+    if is_api_token_applicable(token_name):
+        # if there is no cache yet
+        if os.path.exists('token_cache.json'):
+            cache = safe_read_json('token_cache.json')
+            token_expires_at = datetime.fromtimestamp(cache[f"{token_name}_EXPIRES_AT"])
+            if (token_expires_at - datetime.now()).total_seconds() > 0:
+                return cache[token_name]
+        else:
+            cache = {}
+
+        # Refresh cache
+        credentials = os.getenv("SECRET_MANAGER_CREDENTIALS")
+
+        #token_value, token_expires_in = refreshToken(credentials.username, credentials.password, token_name)
+        token_value, token_expires_in = refreshToken(None, None, token_name)
+
+        # token_expires_in should be in seconds
+        cache[f"{token_name}_EXPIRES_AT"] = datetime.now().timestamp() + token_expires_in
+        cache[token_name] = token_value
+        atomic_write_json('token_cache.json', cache)
+
+        return token_value
+    else:
+        print(f"ERROR: API token {token_name} is not valid.")

--- a/src/morph_kgc/config.py
+++ b/src/morph_kgc/config.py
@@ -41,6 +41,7 @@ ENFORCE_SQL_QUERY_FILTER_NULL = 'enforce_sql_filter_null'
 NUMBER_OF_PROCESSES = 'number_of_processes'
 
 UDFS = 'udfs'
+API_TOKEN = 'api_token'
 
 LOGGING_LEVEL = 'logging_level'
 LOGGING_FILE = 'logging_file'
@@ -80,6 +81,7 @@ DEFAULT_NA_VALUES = ',nan' # ',#N/A,N/A,#N/A N/A,n/a,NA,<NA>,#NA,NULL,null,NaN,n
 DEFAULT_LITERAL_ESCAPING_CHARS = '",\n,\r' # \n,\t,\b,\f,\r,",'
 DEFAULT_ONLY_PRINTABLE_CHARS = 'no'
 DEFAULT_UDFS = ''
+DEFAULT_API_TOKEN = ''
 DEFAULT_OUTPUT_KAFKA_SERVER = ''
 DEFAULT_OUTPUT_KAFKA_TOPIC = ''
 
@@ -103,6 +105,7 @@ CONFIGURATION_OPTIONS_EMPTY_VALID = {
             MAPPING_PARTITIONING: PARTIAL_AGGREGATIONS_PARTITIONING,
             LOGGING_FILE: DEFAULT_LOGGING_FILE,
             UDFS: DEFAULT_UDFS,
+            API_TOKEN: DEFAULT_API_TOKEN,
             OUTPUT_KAFKA_SERVER: DEFAULT_OUTPUT_KAFKA_SERVER,
             OUTPUT_KAFKA_TOPIC: DEFAULT_OUTPUT_KAFKA_TOPIC,
         }
@@ -265,6 +268,9 @@ class Config(ConfigParser):
 
     def get_udfs(self):
         return self.get(self.configuration_section, UDFS)
+
+    def get_api_token(self):
+        return self.get(self.configuration_section, API_TOKEN)
 
     def get_output_file_path(self, mapping_group=None):
         file_extension = OUTPUT_FORMAT_FILE_EXTENSION[self.get_output_format()]


### PR DESCRIPTION
Addresses #341.

New config paramenter `api_token` to provide the file path with the logic to dynamically resolve API tokens. Example of a Python file that implements this logic using a cache:

```python
import json, os, tempfile
from datetime import datetime

def is_api_token_applicable(token):
    # Checks whether the token is within a predefined list of valid tokens
    return token in ["AUTH_TOKEN"]

def atomic_write_json(path, data):
    if not os.path.exists(path):
        with open(path, "a"):
            pass

    dir_name = os.path.dirname(os.path.abspath(path)) or "."
    fd, tmp_path = tempfile.mkstemp(dir=dir_name, prefix=".tmp_", suffix=".json")
    try:
        with os.fdopen(fd, "w", encoding="utf-8") as f:
            json.dump(data, f, ensure_ascii=False, indent=2)
            f.flush()
            os.fsync(f.fileno())
        # Atomic replace across platforms (renaming a file is atomic)
        os.replace(tmp_path, path)
    finally:
        # If something failed before replace, clean up
        if os.path.exists(tmp_path):
            try: os.remove(tmp_path)
            except: pass

def safe_read_json(path):
    with open(path, "r", encoding="utf-8") as f:
        return json.load(f)

def refreshToken(username, password, token_name):
    # Implementation-specific logic to retrieve a new token
    return 'SOME_VALUE', 10 # value, exp_time

def get_api_token(token_name):
    if is_api_token_applicable(token_name):
        # if there is no cache yet
        if os.path.exists('token_cache.json'):
            cache = safe_read_json('token_cache.json')
            token_expires_at = datetime.fromtimestamp(cache[f"{token_name}_EXPIRES_AT"])
            if (token_expires_at - datetime.now()).total_seconds() > 0:
                return cache[token_name]
        else:
            cache = {}

        # Refresh cache
        credentials = os.getenv("SECRET_MANAGER_CREDENTIALS")

        #token_value, token_expires_in = refreshToken(credentials.username, credentials.password, token_name)
        token_value, token_expires_in = refreshToken(None, None, token_name)

        # token_expires_in should be in seconds
        cache[f"{token_name}_EXPIRES_AT"] = datetime.now().timestamp() + token_expires_in
        cache[token_name] = token_value
        atomic_write_json('token_cache.json', cache)

        return token_value
    else:
        print(f"ERROR: API token {token_name} is not valid.")
```


