### PR TITLE
[Draft] Reproduction: RFC 9535 filter syntax (&&) yields empty results

### DIFF
--- a/test/rml-core/json/rfc-standard-filter/data.json
+++ b/test/rml-core/json/rfc-standard-filter/data.json
@@ -1,0 +1,8 @@
+{
+    "sensors": [
+        { "id": "sens1", "type": "co2", "value": 800, "status": "active" },
+        { "id": "sens2", "type": "co2", "value": 1200, "status": "maintenance" },
+        { "id": "sens3", "type": "temp", "value": 25, "status": "active" },
+        { "id": "sens4", "type": "co2", "value": 1500, "status": "active" }
+    ]
+}

--- a/test/rml-core/json/rfc-standard-filter/expected_output.ttl
+++ b/test/rml-core/json/rfc-standard-filter/expected_output.ttl
@@ -1,0 +1,4 @@
+<http://example.com/sensor/sens1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.com/ActiveCO2Sensor> .
+<http://example.com/sensor/sens1> <http://example.com/hasValue> "800"^^<http://www.w3.org/2001/XMLSchema#integer> .
+<http://example.com/sensor/sens4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.com/ActiveCO2Sensor> .
+<http://example.com/sensor/sens4> <http://example.com/hasValue> "1500"^^<http://www.w3.org/2001/XMLSchema#integer> .

--- a/test/rml-core/json/rfc-standard-filter/mapping.ttl
+++ b/test/rml-core/json/rfc-standard-filter/mapping.ttl
@@ -1,0 +1,25 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:MappingActiveCO2
+    a rr:TriplesMap ;
+    rml:logicalSource [
+        rml:source "test/rml-core/json/rfc-standard-filter/data.json" ;
+        rml:referenceFormulation ql:JSONPath ;
+        # The && operator which fails in the current library
+        rml:iterator "$.sensors[?(@.type == 'co2' && @.status == 'active')]"
+    ] ;
+    rr:subjectMap [
+        rr:template "http://example.com/sensor/{id}" ;
+        rr:class ex:ActiveCO2Sensor ;
+    ] ;
+    rr:predicateObjectMap [
+        rr:predicate ex:hasValue ;
+        rr:objectMap [
+            rml:reference "value" ;
+            rr:datatype xsd:integer ;
+        ] ;
+    ] .

--- a/test/rml-core/json/rfc-standard-filter/test_rfc_standard_filter.py
+++ b/test/rml-core/json/rfc-standard-filter/test_rfc_standard_filter.py
@@ -1,0 +1,17 @@
+import morph_kgc
+
+def test_rfc_standard_filter_crash():
+    """
+    This test attempts to use the '&&' operator in a JSONPath filter.
+    On the current Morph-KGC, this should FAIL (raise an exception).
+    """
+
+    config = """
+    [DataSource]
+    mappings: test/rml-core/json/rfc-standard-filter/mapping.ttl
+    """
+
+    g = morph_kgc.materialize(config)
+
+    # We expect 2 sensors (sens1 and sens4) to pass the filter.
+    assert len(g) == 4  # 4 triples total (2 sensors * 2 triples each)


### PR DESCRIPTION
**Description**
This PR adds a test case demonstrating that the current JSONPath implementation fails to parse standard logical operators (`&&`) correctly.

**Reproduction Details**
* **Test Case:** `test/rml-core/json/rfc-standard-filter`
* **Filter Used:** `$.sensors[?(@.type == 'co2' && @.status == 'active')]`
* **Expected Result:** 4 matching triples (2 sensors).
* **Actual Result:** 0 triples (Silent failure / Empty graph).

**Relation to Issues**
Relates to #361 