### PR TITLE
Fix http_api filters match with key when reference doesn't exist

### DIFF
--- a/src/morph_kgc/data_source/http_api.py
+++ b/src/morph_kgc/data_source/http_api.py
@@ -6,13 +6,26 @@ __maintainer__ = "Julián Arenas-Guerrero"
 __email__ = "arenas.guerrero.julian@outlook.com"
 
 
-import json
-import urllib.request
 import pandas as pd
+import os
+import importlib.util
+import sys
 
+from pathlib import Path
 from jsonpath import JSONPath
 from io import StringIO
 from ..utils import normalize_hierarchical_data
+
+
+def load_module_from_path(module_name, file_path):
+    file_path = str(Path(file_path).resolve())
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load spec for {module_name} from {file_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    sys.modules[module_name] = module  # optional: register for reuse
+    return module
 
 
 def get_http_api_data(config, rml_rule, references):
@@ -25,10 +38,16 @@ def get_http_api_data(config, rml_rule, references):
     headers = {}
     if 'field_name' in df.columns:
         for i, row in df.iterrows():
-            if row['field_name'].lower() in ['authorization', 'accept', 'keyid', 'user-agent']:
-                headers[row['field_name']] = row['field_value']
+            if row['field_name'] in os.environ:
+                field_value = row['field_value'].format(**os.environ)
             else:
-                payload[row['field_name']] = row['field_value']
+                mod = load_module_from_path("dynamic_api_token", config.get_api_token())
+                field_value = mod.get_api_token(arg1=row['field_value'])
+
+            if row['field_name'].lower() in ['authorization', 'accept', 'keyid', 'user-agent']:
+                headers[row['field_name']] = field_value
+            else:
+                payload[row['field_name']] = field_value
     json_data = requests.get(absolute_path, params=payload, headers=headers).json()
 
     # Check if any of the references have a JSONPath filter; it's treated differently.
@@ -51,7 +70,6 @@ def get_http_api_data(config, rml_rule, references):
     # normalize and remove nulls
     json_df = pd.json_normalize([json_object for json_object in normalize_hierarchical_data(jsonpath_result) if
                                  None not in json_object.values()])
-    
     if filter_refs:
             join_key = simple_refs[0] 
             entries = JSONPath("$.*").parse(json_data)
@@ -74,7 +92,6 @@ def get_http_api_data(config, rml_rule, references):
     #json_df.dropna(axis=1, how='any', inplace=True) #This removes everything if threres a null; it should only keep the columns that are in the reference and remove the rest.
     # Drop rows with None values in some columns
     json_df = json_df.dropna(axis=0, how='any', subset=[c for c in references if c in json_df.columns])
-    #
     json_df = json_df[[c for c in references if c in json_df.columns]] #Take only the columns that are in the references.
 
     return json_df


### PR DESCRIPTION
There was a bug when matching json_df simple_refs columns with filter references columns. When the value for the filter columns was None or non existent, it didn't count, so the dimension of simple_refs column didn't match with filter columns, concluding in a incorrect match.  

To fix this, now we iterate over some simple_ref column and extract the filtered columns (None if it doesn't match) so that we keep the information of which value of the filter columns corresponds with the simple_refs.