### PR TITLE
Handle missing keys with JSONPath

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
   'rdflib>=6.1.1, <7.3.0',
   'pyoxigraph>=0.3.0, <0.4.0',
   'ruamel.yaml>=0.18.0, <0.19.0',
-  'jsonpath-python==1.0.6',# <2.0.0',
+  'jsonpath-python>=1.1.1',
   'elementpath>=4.0.0, <5.0.0',
   'duckdb>=1.0.0, <2.0.0',
   'falcon>=3.0.0, <5.0.0'

--- a/src/morph_kgc/data_source/http_api.py
+++ b/src/morph_kgc/data_source/http_api.py
@@ -68,10 +68,14 @@ def get_http_api_data(config, rml_rule, references):
     jsonpath_result = JSONPath(jsonpath_expression).parse(json_data)
 
     # normalize and remove nulls
-    json_df = pd.json_normalize([json_object for json_object in normalize_hierarchical_data(jsonpath_result) if
-                                 None not in json_object.values()])
+    json_df = pd.json_normalize([
+        json_object
+        for json_object in normalize_hierarchical_data(jsonpath_result)
+        if None not in json_object.values()
+        and all(reference.split('.')[0] in json_object for reference in simple_refs)
+    ])
     if filter_refs:
-        join_key = simple_refs[0] 
+        join_key = simple_refs[0]
         entries = JSONPath("$.*").parse(json_data)
         lookup_data = {item.get(join_key): item for item in entries if item.get(join_key)}
 

--- a/src/morph_kgc/data_source/python_data.py
+++ b/src/morph_kgc/data_source/python_data.py
@@ -56,8 +56,12 @@ def _read_inmemory_json(source_value, rml_rule, references):
 
     jsonpath_result = JSONPath(jsonpath_expression).parse(json_data)
     # normalize and remove nulls
-    json_df = pd.json_normalize([json_object for json_object in normalize_hierarchical_data(jsonpath_result) if
-                                 None not in json_object.values()])
+    json_df = pd.json_normalize([
+        json_object
+        for json_object in normalize_hierarchical_data(jsonpath_result)
+        if None not in json_object.values()
+        and all(reference.split('.')[0] in json_object for reference in references)
+    ])
 
     # add columns with null values for those references in the mapping rule that are not present in the data file
     missing_references_in_df = list(set(references).difference(set(json_df.columns)))


### PR DESCRIPTION
With `jsonpath-python>=1.1.0`, issue #352 popped up.

The upstream culprit is sean2077/jsonpath-python#18, specifically commit [5e38031 (“resolve issue #9 by filtering out missing keys in field extractor”).
](https://github.com/sean2077/jsonpath-python/pull/18/changes/5e38031611c3623910150320760abd5c852c93aa)

That commit changes field-extractor behavior from emitting missing keys as `None` to omitting missing keys.

I verified across versions with isolated installs:
1.0.6 → returns {'Sport': None} for missing Sport
1.1.0 → omits Sport
1.1.1 → still omits Sport

While you could indeed transition to a better JSONPath library in the sense that its maintainership doesn't make such sweeping breaking changes in this way, I propose to upgrade all current dependencies first to their latest versions, address #374, and then optimize dependencies. uv allows for easier experimentation and structuring of dependencies (e.g., better differentiation between optional and dev-dependencies, and installing dependencies from specific branches/revisions, faster builds).

Resolves #352.