### PR TITLE
Use reference `list` not `set`

### DIFF
--- a/src/morph_kgc/utils.py
+++ b/src/morph_kgc/utils.py
@@ -242,7 +242,7 @@ def remove_null_values_from_dataframe(data, config, references, column=None):
             data[column] = data[column].replace(config.get_na_values(), None)
         else:
             data = data.replace(config.get_na_values(), None)
-        data = data.dropna(axis=0, how='any', subset=references)
+        data = data.dropna(axis=0, how='any', subset=references if isinstance(references, str) else list(references))
 
     return data
 


### PR DESCRIPTION
The docs for `DataFrame.dropna` are ambiguous but using a `set` leads to a NumPy exception, I found during debugging. This fix fixed that completely. This could be because I was testing a newer NumPy version, the set had two members or the variable references weren't correct (uppercase instead of lowercase). In any case, this path triggered an exception.